### PR TITLE
新規作成画面の実装

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,26 +6,27 @@ class NotesController < ApplicationController
 
   def new
     @note = Note.new
+    @emotions = Emotion.all
   end
 
   def create
     @note = Note.new(note_params)
-    unless params[:note][:emotion].nil?
-      params[:note][:emotion].each do |key, value|  
-        if value == false
-          next
-        else
-          emotion_id = Emotion.find_by(emotion_name: key).id
-          note_emotion = NoteEmotion.create(note_id: @note.id, emotion_id: emotion_id)
-        end
+    @emotion_ids = params[:note][:emotion_ids]
+    @emotion_ids.shift
+    if @note.save
+      @emotion_ids.each do |emotion_id|
+        emotion = Emotion.find(emotion_id.to_i)
+        @note.emotions << emotion
       end
-      redirect_to 
+      redirect_to root_path
     else
       render :new
     end
-    redirect_to root_path
   end
   
+  def show
+  end
+
   def edit
     if current_user != @note.user 
       redirect_to root
@@ -35,10 +36,10 @@ class NotesController < ApplicationController
   private
 
   def note_params
-    params.require(:note).permit(:when, :fact, :visibility_id, :wanted_to, :wanted_you_to).merge(user_id: current_user.id)
+    params.require(:note).permit(:when, :fact, :visibility_id, :wanted_to, :wanted_you_to, emotion_ids: []).merge(user_id: current_user.id)
   end
 
   def note_find
-    @note = Item.find(params[:id])
+    @note = Note.find(params[:id])
   end
 end

--- a/app/models/emotion.rb
+++ b/app/models/emotion.rb
@@ -1,7 +1,7 @@
 class Emotion < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  has_many :notes, through: :note_emotions
   has_many :note_emotions
+  has_many :notes, through: :note_emotions
 
   validates :emotion_name, presence: true
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,8 +2,8 @@ class Note < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   has_one :visibility
   belongs_to :user
-  has_many :emotions, through: :note_emotions
   has_many :note_emotions
+  has_many :emotions, through: :note_emotions
 
   validates :fact, presence: true
 end

--- a/app/views/notes/edit.slim
+++ b/app/views/notes/edit.slim
@@ -1,0 +1,1 @@
+h2 notes#edit

--- a/app/views/notes/index.slim
+++ b/app/views/notes/index.slim
@@ -4,4 +4,4 @@ h3 Notes#index
 
 - @notes.each do |note|
   - unless note.visibility_id == 2
-    p = note.fact
+    p = link_to note.fact, note_path(note.id)

--- a/app/views/notes/new.slim
+++ b/app/views/notes/new.slim
@@ -7,11 +7,7 @@ h2 Notes#new
   = f.text_area :fact, placeholder:"自分が気にしていることを言われた"
 
   p そのときどんな気持ちになりましたか？いくつでもチェックしてください。
-  = f.fields_for :emotion do |e|
-    - Emotion.all.each do  |emotion|
-      = e.check_box emotion.emotion_name, {}, true, false
-      = e.label emotion.emotion_name
-  / = collection_check_boxes :note, :emotion_ids, Emotion.all, :id, :emotion_name
+  = f.collection_check_boxes :emotion_ids, @emotions, :id, :emotion_name
 
   p そのとき自分はどうしたかったですか？
   = f.text_area :wanted_to, placeholdar:"嫌な気持ちになったことを伝えたかった"

--- a/app/views/notes/show.slim
+++ b/app/views/notes/show.slim
@@ -1,0 +1,15 @@
+h2 notes#show 
+p いつ
+= @note.when
+p あったこと
+= @note.fact
+p そのときの気持ち
+= @note.emotions.pluck(:emotion_name).join(",")
+p そのときしたかったこと
+= @note.wanted_to
+p そのときしてほしかったこと
+= @note.wanted_you_to
+
+- if current_user == @note.user
+  p = link_to '編集する', edit_note_path(@note.id)
+  p = link_to '削除する', note_path(@note.id), method: :delete


### PR DESCRIPTION
## 受け入れ条件

- [x]  factが入力されていないとき、同ページがレンダリングされる
- [x]  factが入力されて「次へ」が押されたとき、notesテーブルに情報が保存される
- [x]  emotion, wanted_to, wanted_you_to, visibility_idの入力ができる

### memo

- [x]  emotionモデルの作成
    - [x]  中間テーブルの作成
- [x]  バリデーションのチェック


## UI変更
![スクリーンショット 2021-11-26 19 56 37](https://user-images.githubusercontent.com/59994096/143570276-1ceecb83-adec-4e5f-b8db-1b1fb264da44.png)
